### PR TITLE
downgrade debezium connector mariadb to 3.0.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME = debezium-connector-mariadb
-VERSION=3.0.8
+VERSION=3.0.7
 LIBS_DIR = libs
 BUILD_DIR = target
 DIST_DIR = plugin-dist

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <debezium.version>3.0.8.Final</debezium.version>
+        <debezium.version>3.0.7.Final</debezium.version>
         <aws.sdk.version>2.20.17</aws.sdk.version>
         <glue.converter.version>1.1.23</glue.converter.version>
     </properties>


### PR DESCRIPTION
An error occurred when using the following versions with AWS MSK Connector.

- 3.1.1 --> error (;_;)
- 3.0.8 --> error (;_;)